### PR TITLE
feat: contact page and navbar revamp

### DIFF
--- a/app/(site)/about/page.tsx
+++ b/app/(site)/about/page.tsx
@@ -20,7 +20,7 @@ export default async function AboutPage() {
 
   return (
     <Container>
-      <div className="py-16 sm:py-24 space-y-10">
+      <div className="pt-16 pb-10 sm:pt-24 sm:pb-12 space-y-10">
         <IdentityLine markdown={home.identityLine} />
         <Prose html={html} />
       </div>

--- a/app/(site)/booking/page.tsx
+++ b/app/(site)/booking/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import RedirectShell from "../../_components/RedirectShell";
+import { getWorkTogetherPage } from "../../../lib/content";
+
+export const metadata: Metadata = { title: "Redirecting to booking..." };
+
+export default async function BookingPage() {
+  const { frontmatter } = await getWorkTogetherPage();
+  const url = frontmatter.bookingUrl ?? "https://calendly.com/wharris-cal";
+  return (
+    <>
+      <meta httpEquiv="refresh" content={`2;url=${url}`} />
+      <RedirectShell redirectTo={url} label="Taking you to booking" />
+    </>
+  );
+}

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,15 +1,95 @@
 import type { Metadata } from "next";
-import RedirectShell from "../../_components/RedirectShell";
-import { getRedirectPage } from "../../../lib/content";
+import Container from "../../_components/Container";
+import CTAButton from "../../_components/CTAButton";
+import { getHomePage, getWorkTogetherPage } from "../../../lib/content";
 
-export const metadata: Metadata = { title: "Redirecting..." };
+export const metadata: Metadata = {
+  title: "Contact | William Harris",
+};
+
+interface LinkCardProps {
+  href: string;
+  label: string;
+  sublabel?: string;
+  external?: boolean;
+}
+
+function LinkCard({ href, label, sublabel, external }: LinkCardProps) {
+  return (
+    <a
+      href={href}
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      className="block w-full rounded-md border border-border bg-surface px-5 py-4 no-underline hover:border-accent transition-colors"
+    >
+      <span className="block text-base font-medium text-text">{label}</span>
+      {sublabel && (
+        <span className="block text-sm text-text-muted mt-0.5">{sublabel}</span>
+      )}
+    </a>
+  );
+}
 
 export default async function ContactPage() {
-  const { frontmatter } = await getRedirectPage("contact");
+  const [home, workTogether] = await Promise.all([
+    getHomePage(),
+    getWorkTogetherPage(),
+  ]);
+
+  const bookingUrl =
+    workTogether.frontmatter.bookingUrl ?? "https://calendly.com/wharris-cal";
+
+  const socialLinks = home.frontmatter.socialLinks ?? [];
+  const linkedIn = socialLinks.find((l) =>
+    l.label.toLowerCase().includes("linkedin")
+  );
+  const twitter = socialLinks.find(
+    (l) =>
+      l.label.toLowerCase().includes("twitter") ||
+      l.label.toLowerCase().includes("x")
+  );
+
   return (
-    <>
-      <meta httpEquiv="refresh" content={`2;url=${frontmatter.redirectTo}`} />
-      <RedirectShell redirectTo={frontmatter.redirectTo} />
-    </>
+    <Container>
+      <div className="pt-10 pb-16 sm:pt-14 sm:pb-24 max-w-sm mx-auto space-y-10">
+        <div className="space-y-2">
+          <p className="text-xs uppercase tracking-wide text-text-muted m-0">
+            Contact
+          </p>
+          <h1 className="font-display text-4xl m-0">Get in touch</h1>
+        </div>
+
+        <div className="space-y-3">
+          <LinkCard
+            href="/booking/"
+            label="Book time with me"
+            sublabel="Schedule a call via Calendly"
+          />
+          <LinkCard
+            href="mailto:wharris@upscalews.com"
+            label="Email"
+            sublabel="wharris@upscalews.com"
+            external
+          />
+          {linkedIn && (
+            <LinkCard
+              href={linkedIn.url}
+              label="LinkedIn"
+              sublabel={linkedIn.url.replace("https://", "")}
+              external
+            />
+          )}
+          {twitter && (
+            <LinkCard
+              href={twitter.url}
+              label="Twitter / X"
+              sublabel={twitter.url.replace("https://", "")}
+              external
+            />
+          )}
+        </div>
+
+        <CTAButton href="/work-together/">Work with me</CTAButton>
+      </div>
+    </Container>
   );
 }

--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -14,7 +14,7 @@ export default function Footer({ data }: FooterProps) {
   }));
 
   return (
-    <footer className="mt-[var(--spacing-section)] border-t border-border py-10">
+    <footer className="border-t border-border py-10">
       <Container width="wide">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="m-0 text-sm text-text-muted">

--- a/src/content/footer/index.md
+++ b/src/content/footer/index.md
@@ -8,18 +8,18 @@ logoImage:
   imageAlt: JavaScript Wakanda Forever!
   tagline: Your friendly local web developers
 footerLinks:
-  - image: /img/email.svg
-    imageAlt: Contact me via the emails
-    label: email me
-    linkURL: mailto:wharris@upscalews.com
-  - image: /img/twitter.svg
-    imageAlt: boujeehacker on twitter
-    label: tweet me at boujeehacker
-    linkURL: https://twitter.com/boujeehacker
   - image: /img/vulk-logo-marque-light.svg
     imageAlt: People I work with
     label: vulk.coop - frequent collaborators
     linkURL: http://vulk.coop/
+  - image: /img/email.svg
+    imageAlt: articles on substack
+    label: articles
+    linkURL: https://boujeehacker.substack.com
+  - image: /img/twitter.svg
+    imageAlt: boujeehacker on twitter (x)
+    label: boujeehacker on twitter (x)
+    linkURL: https://x.com/boujeehacker
   - image: /img/GitHub-Mark-Light-120px-plus.png
     imageAlt: The source of this site
     label: boujeehacker.com on github

--- a/src/content/navbar/index.md
+++ b/src/content/navbar/index.md
@@ -4,9 +4,6 @@ menuItems:
   - label: about
     linkType: internal
     linkURL: /about/
-  - label: articles
-    linkType: external
-    linkURL: https://boujeehacker.substack.com
   - label: work together
     linkType: internal
     linkURL: /work-together/


### PR DESCRIPTION
**feat: links & contact revamp**

- **`/contact`** replaced with a linktree-style page (Book time, Email, LinkedIn, Twitter/X)
- **`/booking`** new route — preserves the Calendly redirect + Computer Doggo for existing tracking instrumentation
- **Navbar** — removed `articles` link; now `about | work together | contact`
- **Footer** — swapped `email me` for `articles` (Substack); removed 80px top margin that was creating excess whitespace above the footer
- **`/about`** — tightened bottom padding (96px → 48px)