### PR TITLE
fix: analytics

### DIFF
--- a/app/(site)/booking/page.tsx
+++ b/app/(site)/booking/page.tsx
@@ -10,7 +10,11 @@ export default async function BookingPage() {
   return (
     <>
       <meta httpEquiv="refresh" content={`2;url=${url}`} />
-      <RedirectShell redirectTo={url} label="Taking you to booking" />
+      <RedirectShell
+        redirectTo={url}
+        label="Taking you to booking"
+        redirectName="booking"
+      />
     </>
   );
 }

--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -1,33 +1,12 @@
 import type { Metadata } from "next";
 import Container from "../../_components/Container";
 import CTAButton from "../../_components/CTAButton";
+import ContactLinkCard from "../../_components/ContactLinkCard";
 import { getHomePage, getWorkTogetherPage } from "../../../lib/content";
 
 export const metadata: Metadata = {
   title: "Contact | William Harris",
 };
-
-interface LinkCardProps {
-  href: string;
-  label: string;
-  sublabel?: string;
-  external?: boolean;
-}
-
-function LinkCard({ href, label, sublabel, external }: LinkCardProps) {
-  return (
-    <a
-      href={href}
-      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
-      className="block w-full rounded-md border border-border bg-surface px-5 py-4 no-underline hover:border-accent transition-colors"
-    >
-      <span className="block text-base font-medium text-text">{label}</span>
-      {sublabel && (
-        <span className="block text-sm text-text-muted mt-0.5">{sublabel}</span>
-      )}
-    </a>
-  );
-}
 
 export default async function ContactPage() {
   const [home, workTogether] = await Promise.all([
@@ -59,19 +38,19 @@ export default async function ContactPage() {
         </div>
 
         <div className="space-y-3">
-          <LinkCard
+          <ContactLinkCard
             href="/booking/"
             label="Book time with me"
             sublabel="Schedule a call via Calendly"
           />
-          <LinkCard
+          <ContactLinkCard
             href="mailto:wharris@upscalews.com"
             label="Email"
             sublabel="wharris@upscalews.com"
             external
           />
           {linkedIn && (
-            <LinkCard
+            <ContactLinkCard
               href={linkedIn.url}
               label="LinkedIn"
               sublabel={linkedIn.url.replace("https://", "")}
@@ -79,7 +58,7 @@ export default async function ContactPage() {
             />
           )}
           {twitter && (
-            <LinkCard
+            <ContactLinkCard
               href={twitter.url}
               label="Twitter / X"
               sublabel={twitter.url.replace("https://", "")}

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -34,6 +34,7 @@ export default async function SiteLayout({
               loaded: (posthog) => {
                 window.analytics.page();
               },
+              debug: true,
             });
           })
 

--- a/app/(site)/layout.tsx
+++ b/app/(site)/layout.tsx
@@ -29,12 +29,11 @@ export default async function SiteLayout({
             window.posthog.init(POSTHOG_API_KEY, {
               api_host: 'https://us.i.posthog.com',
               segment: window.analytics,
-              capture_pageview: true,
+              capture_pageview: false,
               capture_pageleave: true,
               loaded: (posthog) => {
                 window.analytics.page();
               },
-              debug: true,
             });
           })
 

--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -1,28 +1,43 @@
+"use client";
+
 import Link from "next/link";
 import type { ReactNode } from "react";
+import { trackLinkClick } from "./trackLinkClick";
 
 export default function CTAButton({
   href,
   children,
   external = false,
+  location = "cta-button",
 }: {
   href: string;
   children: ReactNode;
   external?: boolean;
+  location?: string;
 }) {
   const className =
     "inline-flex items-center gap-2 rounded-md bg-accent px-5 py-3 text-bg no-underline font-medium transition-colors duration-[var(--transition-duration)] hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2";
 
+  const text = typeof children === "string" ? children : "";
+  const onClick = () =>
+    trackLinkClick({ href, text, location, external });
+
   if (external) {
     return (
-      <a href={href} className={className} target="_blank" rel="noopener">
+      <a
+        href={href}
+        className={className}
+        target="_blank"
+        rel="noopener"
+        onClick={onClick}
+      >
         {children}
         <span aria-hidden>→</span>
       </a>
     );
   }
   return (
-    <Link href={href} className={className}>
+    <Link href={href} className={className} onClick={onClick}>
       {children}
       <span aria-hidden>→</span>
     </Link>

--- a/app/_components/CTAButton.tsx
+++ b/app/_components/CTAButton.tsx
@@ -19,8 +19,8 @@ export default function CTAButton({
     "inline-flex items-center gap-2 rounded-md bg-accent px-5 py-3 text-bg no-underline font-medium transition-colors duration-[var(--transition-duration)] hover:bg-accent-hover focus-visible:outline-2 focus-visible:outline-focus focus-visible:outline-offset-2";
 
   const text = typeof children === "string" ? children : "";
-  const onClick = () =>
-    trackLinkClick({ href, text, location, external });
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) =>
+    trackLinkClick({ href, text, location, external }, e);
 
   if (external) {
     return (

--- a/app/_components/ContactLinkCard.tsx
+++ b/app/_components/ContactLinkCard.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { trackLinkClick } from "./trackLinkClick";
+
+interface ContactLinkCardProps {
+  href: string;
+  label: string;
+  sublabel?: string;
+  external?: boolean;
+}
+
+export default function ContactLinkCard({
+  href,
+  label,
+  sublabel,
+  external,
+}: ContactLinkCardProps) {
+  return (
+    <a
+      href={href}
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      onClick={(e) =>
+        trackLinkClick(
+          { href, text: label, location: "contact-card", external },
+          e,
+        )
+      }
+      className="block w-full rounded-md border border-border bg-surface px-5 py-4 no-underline hover:border-accent transition-colors"
+    >
+      <span className="block text-base font-medium text-text">{label}</span>
+      {sublabel && (
+        <span className="block text-sm text-text-muted mt-0.5">{sublabel}</span>
+      )}
+    </a>
+  );
+}

--- a/app/_components/CustomLink.tsx
+++ b/app/_components/CustomLink.tsx
@@ -1,12 +1,16 @@
+"use client";
+
 import Link from "next/link";
 import type { ReactNode } from "react";
 import type { LinkType } from "../../lib/content-types";
+import { trackLinkClick } from "./trackLinkClick";
 
 interface CustomLinkProps {
   linkType: LinkType;
   linkURL: string;
   children: ReactNode;
   className?: string;
+  location?: string;
 }
 
 export default function CustomLink({
@@ -14,16 +18,32 @@ export default function CustomLink({
   linkURL,
   children,
   className = "",
+  location = "unknown",
 }: CustomLinkProps) {
+  const text = typeof children === "string" ? children : "";
+  const onClick = () =>
+    trackLinkClick({
+      href: linkURL,
+      text,
+      location,
+      external: linkType !== "internal",
+    });
+
   if (linkType === "internal") {
     return (
-      <Link className={className} href={linkURL}>
+      <Link className={className} href={linkURL} onClick={onClick}>
         {children}
       </Link>
     );
   }
   return (
-    <a className={className} href={linkURL} target="_blank" rel="noopener">
+    <a
+      className={className}
+      href={linkURL}
+      target="_blank"
+      rel="noopener"
+      onClick={onClick}
+    >
       {children}
     </a>
   );

--- a/app/_components/CustomLink.tsx
+++ b/app/_components/CustomLink.tsx
@@ -21,13 +21,16 @@ export default function CustomLink({
   location = "unknown",
 }: CustomLinkProps) {
   const text = typeof children === "string" ? children : "";
-  const onClick = () =>
-    trackLinkClick({
-      href: linkURL,
-      text,
-      location,
-      external: linkType !== "internal",
-    });
+  const onClick = (e: React.MouseEvent<HTMLAnchorElement>) =>
+    trackLinkClick(
+      {
+        href: linkURL,
+        text,
+        location,
+        external: linkType !== "internal",
+      },
+      e,
+    );
 
   if (linkType === "internal") {
     return (

--- a/app/_components/Footer.tsx
+++ b/app/_components/Footer.tsx
@@ -20,7 +20,7 @@ export default function Footer({ data }: FooterProps) {
           <p className="m-0 text-sm text-text-muted">
             © {year} William Harris
           </p>
-          {links.length > 0 && <SocialLinkRow links={links} />}
+          {links.length > 0 && <SocialLinkRow links={links} location="footer" />}
         </div>
       </Container>
     </footer>

--- a/app/_components/MarkdownLinkInBlank.tsx
+++ b/app/_components/MarkdownLinkInBlank.tsx
@@ -12,12 +12,15 @@ export default function MarkdownLinkInBlank({
   ...props
 }: AnchorHTMLAttributes<HTMLAnchorElement>) {
   const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
-    trackLinkClick({
-      href: props.href ?? "",
-      text: typeof props.children === "string" ? props.children : "",
-      location: "markdown-link",
-      external: true,
-    });
+    trackLinkClick(
+      {
+        href: props.href ?? "",
+        text: typeof props.children === "string" ? props.children : "",
+        location: "markdown-link",
+        external: true,
+      },
+      e,
+    );
     onClick?.(e);
   };
 

--- a/app/_components/MarkdownLinkInBlank.tsx
+++ b/app/_components/MarkdownLinkInBlank.tsx
@@ -1,18 +1,33 @@
-import type { AnchorHTMLAttributes } from "react";
+"use client";
+
+import type { AnchorHTMLAttributes, MouseEvent } from "react";
+import { trackLinkClick } from "./trackLinkClick";
 
 const defaultClassName =
   "underline decoration-1 underline-offset-[3px] decoration-border hover:text-link-hover hover:decoration-link-hover";
 
 export default function MarkdownLinkInBlank({
   className,
+  onClick,
   ...props
 }: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    trackLinkClick({
+      href: props.href ?? "",
+      text: typeof props.children === "string" ? props.children : "",
+      location: "markdown-link",
+      external: true,
+    });
+    onClick?.(e);
+  };
+
   return (
     <a
       {...props}
       className={className ?? defaultClassName}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={handleClick}
     />
   );
 }

--- a/app/_components/Navbar.tsx
+++ b/app/_components/Navbar.tsx
@@ -18,12 +18,15 @@ export default function Navbar({ data }: NavbarProps) {
           <Link
             href="/"
             className="font-display text-base sm:text-lg text-text no-underline hover:text-link-hover"
-            onClick={() =>
-              trackLinkClick({
-                href: "/",
-                text: "boujeehacker",
-                location: "navbar-home",
-              })
+            onClick={(e) =>
+              trackLinkClick(
+                {
+                  href: "/",
+                  text: "boujeehacker",
+                  location: "navbar-home",
+                },
+                e,
+              )
             }
           >
             boujeehacker

--- a/app/_components/Navbar.tsx
+++ b/app/_components/Navbar.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import Link from "next/link";
 import CustomLink from "./CustomLink";
 import Container from "./Container";
 import type { NavbarFrontmatter } from "../../lib/content-types";
+import { trackLinkClick } from "./trackLinkClick";
 
 interface NavbarProps {
   data: NavbarFrontmatter;
@@ -15,6 +18,13 @@ export default function Navbar({ data }: NavbarProps) {
           <Link
             href="/"
             className="font-display text-base sm:text-lg text-text no-underline hover:text-link-hover"
+            onClick={() =>
+              trackLinkClick({
+                href: "/",
+                text: "boujeehacker",
+                location: "navbar-home",
+              })
+            }
           >
             boujeehacker
           </Link>
@@ -26,6 +36,7 @@ export default function Navbar({ data }: NavbarProps) {
                     linkType={menuItem.linkType}
                     linkURL={menuItem.linkURL}
                     className="text-text-muted no-underline hover:text-link-hover whitespace-nowrap"
+                    location="navbar"
                   >
                     {menuItem.label}
                   </CustomLink>

--- a/app/_components/RedirectShell.tsx
+++ b/app/_components/RedirectShell.tsx
@@ -2,24 +2,37 @@
 
 import { useEffect } from "react";
 import Container from "./Container";
+import { trackLinkClick } from "./trackLinkClick";
 
 interface RedirectShellProps {
   redirectTo: string;
   label?: string;
+  redirectName?: string;
 }
 
 export default function RedirectShell({
   redirectTo,
   label = "Taking you there",
+  redirectName = "unknown",
 }: RedirectShellProps) {
   useEffect(() => {
+    try {
+      window.analytics?.track("Redirect Started", {
+        redirect_name: redirectName,
+        destination: redirectTo,
+        current_path: window.location.pathname,
+      });
+    } catch {
+      // analytics not loaded — don't block redirect
+    }
+
     const timer = setTimeout(() => {
       if (redirectTo) {
         window.location.href = redirectTo;
       }
     }, 2500);
     return () => clearTimeout(timer);
-  }, [redirectTo]);
+  }, [redirectTo, redirectName]);
 
   return (
     <Container>
@@ -45,6 +58,17 @@ export default function RedirectShell({
           <a
             href={redirectTo}
             className="underline decoration-border underline-offset-[3px] hover:text-link-hover hover:decoration-link-hover"
+            onClick={(e) =>
+              trackLinkClick(
+                {
+                  href: redirectTo,
+                  text: "click here",
+                  location: `redirect-fallback:${redirectName}`,
+                  external: true,
+                },
+                e,
+              )
+            }
           >
             click here
           </a>

--- a/app/_components/SocialLinkRow.tsx
+++ b/app/_components/SocialLinkRow.tsx
@@ -1,9 +1,19 @@
+"use client";
+
+import { trackLinkClick } from "./trackLinkClick";
+
 export interface SocialLink {
   label: string;
   href: string;
 }
 
-export default function SocialLinkRow({ links }: { links: SocialLink[] }) {
+export default function SocialLinkRow({
+  links,
+  location = "social-row",
+}: {
+  links: SocialLink[];
+  location?: string;
+}) {
   return (
     <ul className="flex flex-wrap gap-x-5 gap-y-2 list-none p-0 m-0 text-sm text-text-muted">
       {links.map((link) => (
@@ -13,6 +23,14 @@ export default function SocialLinkRow({ links }: { links: SocialLink[] }) {
             target="_blank"
             rel="noopener"
             className="text-text-muted no-underline hover:text-link-hover hover:underline"
+            onClick={() =>
+              trackLinkClick({
+                href: link.href,
+                text: link.label,
+                location,
+                external: true,
+              })
+            }
           >
             {link.label}
           </a>

--- a/app/_components/SocialLinkRow.tsx
+++ b/app/_components/SocialLinkRow.tsx
@@ -23,13 +23,16 @@ export default function SocialLinkRow({
             target="_blank"
             rel="noopener"
             className="text-text-muted no-underline hover:text-link-hover hover:underline"
-            onClick={() =>
-              trackLinkClick({
-                href: link.href,
-                text: link.label,
-                location,
-                external: true,
-              })
+            onClick={(e) =>
+              trackLinkClick(
+                {
+                  href: link.href,
+                  text: link.label,
+                  location,
+                  external: true,
+                },
+                e,
+              )
             }
           >
             {link.label}

--- a/app/_components/WorkCard.tsx
+++ b/app/_components/WorkCard.tsx
@@ -18,13 +18,16 @@ export default function WorkCard({ item }: { item: WorkItem }) {
     <a
       href={item.url}
       {...linkProps}
-      onClick={() =>
-        trackLinkClick({
-          href: item.url,
-          text: item.title,
-          location: "work-card",
-          external: !isInternal,
-        })
+      onClick={(e) =>
+        trackLinkClick(
+          {
+            href: item.url,
+            text: item.title,
+            location: "work-card",
+            external: !isInternal,
+          },
+          e,
+        )
       }
       className="group block border-t border-border py-5 no-underline transition-colors duration-[var(--transition-duration)] hover:bg-surface/50"
     >

--- a/app/_components/WorkCard.tsx
+++ b/app/_components/WorkCard.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { trackLinkClick } from "./trackLinkClick";
+
 export interface WorkItem {
   title: string;
   outcome: string;
@@ -14,6 +18,14 @@ export default function WorkCard({ item }: { item: WorkItem }) {
     <a
       href={item.url}
       {...linkProps}
+      onClick={() =>
+        trackLinkClick({
+          href: item.url,
+          text: item.title,
+          location: "work-card",
+          external: !isInternal,
+        })
+      }
       className="group block border-t border-border py-5 no-underline transition-colors duration-[var(--transition-duration)] hover:bg-surface/50"
     >
       <div className="flex items-baseline justify-between gap-4">

--- a/app/_components/trackLinkClick.ts
+++ b/app/_components/trackLinkClick.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import type { MouseEvent } from "react";
+
 declare global {
   interface Window {
     analytics?: {
@@ -8,14 +10,60 @@ declare global {
   }
 }
 
-export function trackLinkClick(properties: {
+interface TrackLinkClickInput {
   href: string;
   text: string;
   location: string;
   external?: boolean;
-}) {
+}
+
+const BUTTON_NAMES = ["left", "middle", "right"] as const;
+
+function getTargetDomain(href: string, currentHost: string): string | null {
   try {
-    window.analytics?.track("Link Clicked", properties);
+    const url = new URL(href, window.location.href);
+    if (!url.host) return null;
+    return url.host === currentHost ? null : url.host;
+  } catch {
+    return null;
+  }
+}
+
+export function trackLinkClick(
+  input: TrackLinkClickInput,
+  event?: MouseEvent<HTMLAnchorElement>,
+) {
+  try {
+    const { href, text, location, external = false } = input;
+    const currentHost = window.location.host;
+    const targetDomain = getTargetDomain(href, currentHost);
+
+    const button = event ? BUTTON_NAMES[event.button] ?? "other" : undefined;
+    const modifierKeys = event
+      ? {
+          ctrl: event.ctrlKey,
+          meta: event.metaKey,
+          shift: event.shiftKey,
+          alt: event.altKey,
+        }
+      : undefined;
+    const opensNewTab = event
+      ? event.metaKey || event.ctrlKey || event.button === 1
+      : undefined;
+
+    window.analytics?.track("Link Clicked", {
+      href,
+      text,
+      location,
+      is_internal: !external,
+      target_domain: targetDomain,
+      current_url: window.location.href,
+      current_path: window.location.pathname,
+      referrer: document.referrer || null,
+      button,
+      modifier_keys: modifierKeys,
+      opens_new_tab: opensNewTab,
+    });
   } catch {
     // analytics not loaded yet — drop the event rather than block navigation
   }

--- a/app/_components/trackLinkClick.ts
+++ b/app/_components/trackLinkClick.ts
@@ -1,0 +1,22 @@
+"use client";
+
+declare global {
+  interface Window {
+    analytics?: {
+      track: (event: string, properties?: Record<string, unknown>) => void;
+    };
+  }
+}
+
+export function trackLinkClick(properties: {
+  href: string;
+  text: string;
+  location: string;
+  external?: boolean;
+}) {
+  try {
+    window.analytics?.track("Link Clicked", properties);
+  } catch {
+    // analytics not loaded yet — drop the event rather than block navigation
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the autocapture-not-working problem and instruments reliable click tracking through Segment, which fans out to PostHog (and any future destinations).

**Root cause:** PostHog autocapture uses `sendBeacon` on unload to ship click events, which is unreliable on link clicks that immediately trigger navigation (per [[posthog-js#205](https://github.com/PostHog/posthog-js/issues/205)](https://github.com/PostHog/posthog-js/issues/205)). That's why `$pageview` events showed up but `$autocapture` clicks didn't.

**Fix:** Route link clicks through `window.analytics.track("Link Clicked", {...})` instead. Segment was already loaded as the main analytics line, and Segment delivers reliably across navigation. PostHog autocapture stays on as a backup.

## Changes

**Config aligned to PostHog's official Segment integration docs** (`app/(site)/layout.tsx`)
- `capture_pageview: false` — Segment owns pageviews now (was double-firing)
- Removed `debug: true` — no verbose console in prod

**New helper** `app/_components/trackLinkClick.ts`
- Wraps `analytics.track("Link Clicked", ...)` with rich properties: `href`, `text`, `location`, `is_internal`, `target_domain`, `current_url`, `current_path`, `referrer`, `button` (left/middle/right), `modifier_keys` (ctrl/meta/shift/alt), `opens_new_tab`
- Generic event name + specific properties follows the Segment "Object Action" semantic spec — keeps funnels/cohorts working

**Instrumented every link entry point**
- `CustomLink`, `CTAButton`, `Navbar` (home + menu), `SocialLinkRow` (footer), `WorkCard`, `MarkdownLinkInBlank`, and new `ContactLinkCard`

**New conversion event** `Redirect Started` in `RedirectShell`
- Fires on `/booking/` so we can see how many people enter the booking funnel vs bounce before the meta-refresh
- Also instrumented the manual "click here" fallback link

## What we explicitly skipped and why
- **Scroll depth, exception capture, heatmaps** — PostHog has these on already (`$pageleave`, `exceptionAutocapture`, `heatmaps` module)
- **Outbound-domain grouping** — already filterable from the `target_domain` property
- **`posthog.identify()` / `group()`** — no user identifier client-side; would be a no-op until we add a form or wire Leadsy → PostHog server-side

## Test plan
- [ ] Click each link surface and confirm `Link Clicked` events arrive in PostHog with full property set
- [ ] Hit `/booking/` directly and confirm a `Redirect Started` event arrives with `redirect_name: "booking"`
- [ ] Confirm `$pageview` events are no longer duplicated (Segment + PostHog were both sending one each)
- [ ] Verify the meta-refresh on `/booking/` still works (autocapture/track shouldn't block it)