### PR TITLE
feat: better cta tracking

### DIFF
--- a/app/(site)/contact/page.tsx
+++ b/app/(site)/contact/page.tsx
@@ -67,7 +67,9 @@ export default async function ContactPage() {
           )}
         </div>
 
-        <CTAButton href="/work-together/">Work with me</CTAButton>
+        <CTAButton href="/work-together/" location="contact-cta">
+          Work with me
+        </CTAButton>
       </div>
     </Container>
   );

--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -33,7 +33,7 @@ export default async function HomePage() {
         <IdentityLine markdown={home.identityLine} />
 
         <div className="flex flex-col gap-5 items-start">
-          <CTAButton href={home.primaryCTA.url}>
+          <CTAButton href={home.primaryCTA.url} location="home-primary-cta">
             {home.primaryCTA.label}
           </CTAButton>
           <SocialLinkRow
@@ -41,6 +41,7 @@ export default async function HomePage() {
               label: l.label,
               href: l.url,
             }))}
+            location="home-socials"
           />
         </div>
 

--- a/app/(site)/preview/page.tsx
+++ b/app/(site)/preview/page.tsx
@@ -16,7 +16,7 @@ export default function PreviewPage() {
           </p>
           <div className="mt-3">
             <IdentityLine
-              markdown={`I'm William Harris. I build software real users depend on, from scrappy startups like early [OpenSea](https://opensea.io) to 300MM+-user systems at [LinkedIn](https://linkedin.com/in/31iqml).`}
+              markdown={`Hi! I'm William Harris. I build software real users depend on, from scrappy startups like early [OpenSea](https://opensea.io) to 300MM+-user systems at [LinkedIn](https://linkedin.com/in/31iqml).`}
             />
           </div>
         </section>

--- a/app/(site)/work-together/DeckLink.tsx
+++ b/app/(site)/work-together/DeckLink.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { trackLinkClick } from "../../_components/trackLinkClick";
+
+export default function DeckLink({
+  url,
+  location,
+  children,
+}: {
+  url: string;
+  location: string;
+  children: ReactNode;
+}) {
+  const text = typeof children === "string" ? children : "pitch-deck";
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener"
+      className="underline decoration-border underline-offset-[3px] hover:text-link-hover hover:decoration-link-hover"
+      onClick={(e) =>
+        trackLinkClick(
+          { href: url, text, location, external: true },
+          e,
+        )
+      }
+    >
+      {children}
+    </a>
+  );
+}

--- a/app/(site)/work-together/page.tsx
+++ b/app/(site)/work-together/page.tsx
@@ -3,6 +3,7 @@ import Container from "../../_components/Container";
 import IdentityLine from "../../_components/IdentityLine";
 import Prose from "../../_components/Prose";
 import CTAButton from "../../_components/CTAButton";
+import DeckLink from "./DeckLink";
 import { getWorkTogetherPage } from "../../../lib/content";
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -13,18 +14,13 @@ export async function generateMetadata(): Promise<Metadata> {
   };
 }
 
-function DeckFootnote({ url }: { url: string }) {
+function DeckFootnote({ url, location }: { url: string; location: string }) {
   return (
     <p className="text-sm text-text-muted m-0">
       Want more details?{" "}
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener"
-        className="underline decoration-border underline-offset-[3px] hover:text-link-hover hover:decoration-link-hover"
-      >
+      <DeckLink url={url} location={location}>
         Here's the pitch deck
-      </a>
+      </DeckLink>
       .
     </p>
   );
@@ -44,7 +40,11 @@ export default async function WorkTogetherPage() {
           <div className="space-y-8 min-w-0">
             {bookingUrl && (
               <div className="lg:hidden">
-                <CTAButton href={bookingUrl} external>
+                <CTAButton
+                  href={bookingUrl}
+                  external
+                  location="work-together-cta-mobile-top"
+                >
                   Book a time
                 </CTAButton>
               </div>
@@ -54,13 +54,20 @@ export default async function WorkTogetherPage() {
 
             <div className="lg:hidden space-y-6">
               {bookingUrl && (
-                <CTAButton href={bookingUrl} external>
+                <CTAButton
+                  href={bookingUrl}
+                  external
+                  location="work-together-cta-mobile-bottom"
+                >
                   Book a time
                 </CTAButton>
               )}
               {deckUrl && (
                 <div className="pt-6 border-t border-border max-w-[var(--measure)]">
-                  <DeckFootnote url={deckUrl} />
+                  <DeckFootnote
+                    url={deckUrl}
+                    location="work-together-deck-mobile"
+                  />
                 </div>
               )}
             </div>
@@ -70,11 +77,20 @@ export default async function WorkTogetherPage() {
           <aside className="hidden lg:block">
             <div className="sticky top-8 space-y-5">
               {bookingUrl && (
-                <CTAButton href={bookingUrl} external>
+                <CTAButton
+                  href={bookingUrl}
+                  external
+                  location="work-together-cta-desktop-sticky"
+                >
                   Book a time
                 </CTAButton>
               )}
-              {deckUrl && <DeckFootnote url={deckUrl} />}
+              {deckUrl && (
+                <DeckFootnote
+                  url={deckUrl}
+                  location="work-together-deck-desktop"
+                />
+              )}
             </div>
           </aside>
         </div>

--- a/src/content/home/index.md
+++ b/src/content/home/index.md
@@ -3,7 +3,7 @@ templateKey: home-page
 avatar:
   image: /img/fb.jpg
   imageAlt: William Harris
-identityLine: I'm [William Harris](/about). I build software real users depend on, from scrappy startups like early [OpenSea](https://opensea.io/) to 300MM+ user systems at [LinkedIn](https://www.linkedin.com/in/31iqml/).
+identityLine: Hi! I'm [William Harris](/about), I build software real users depend on. From scrappy startups like early [OpenSea](https://opensea.io/) to 300MM+ user systems at [LinkedIn](https://www.linkedin.com/in/31iqml/).
 selectedWork:
   - title: BCGX Client Snowflake pipeline; Senior Forward-Deployed Engineer
     outcome: 10M datapoints/day; $10–20M/yr customer savings in transportation logistics


### PR DESCRIPTION
## Summary
- Fix autocapture-not-working by routing link clicks through Segment's `analytics.track("Link Clicked", ...)` — PostHog's autocapture loses click events on navigation ([[posthog-js#205](https://github.com/PostHog/posthog-js/issues/205)](https://github.com/PostHog/posthog-js/issues/205)), Segment delivers reliably and fans out to PostHog plus any future destinations
- Align PostHog init with [official Segment docs] (https://posthog.com/docs/libraries/segment)(https://posthog.com/docs/libraries/segment): `capture_pageview: false` (was double-firing with Segment's `analytics.page()`), drop `debug: true`
- Instrument every CTA with a distinct `location` so funnels can compare placements (home primary, contact card, work-together mobile-top / mobile-bottom / desktop-sticky, pitch deck, etc.)
- Add `Redirect Started` event on `/booking/` to measure booking-funnel entry

Each event carries `href`, `text`, `location`, `is_internal`, `target_domain`, `current_url`, `current_path`, `referrer`, `button`, `modifier_keys`, `opens_new_tab`.

## Test plan
- [ ] Click each CTA and confirm `Link Clicked` arrives in PostHog with the expected `location`
- [ ] Hit `/booking/` and confirm `Redirect Started` fires with `redirect_name: "booking"`
- [ ] Confirm `$pageview` is no longer duplicated
- [ ] Meta-refresh on `/booking/` still works